### PR TITLE
Refactor addition of CSS classes to invalid field

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -127,3 +127,18 @@ This is done using the properties ``field_container_css_class``,
 For all CSS class properties, there are methods to override the applied CSS class
 per field. Please refer to the :doc:`API Reference <api_mixins>` to learn what
 arguments are passed to the CSS class methods.
+
+
+Adding CSS classes to invalid field
+-----------------------------------
+
+When you render the form using `django-tapeforms`, you can also apply additional
+CSS classes to the label and widget of a field which has errors.
+
+This is done using the properties ``field_label_invalid_css_class`` and
+``widget_invalid_css_class``.
+
+If you need to set more attributes to the widget when there are errors, you can
+overwrite the :py:meth:`apply_widget_invalid_options
+<tapeforms.mixins.TapeformMixin.apply_widget_invalid_options()>` method. It
+receives the field name as ``str``.

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -33,8 +33,8 @@ You are done. The ``form`` :doc:`template tag <api_templatetags>` will pick the 
 defined template for rendering.
 
 If you need to select the layout template on other things like the instance
-in ``ModelForm``, you can overwrite the ``get_layout_template`` method (which
-is defined in the ``TapeformMixin``).
+in ``ModelForm``, you can overwrite the :py:meth:`get_layout_template
+<tapeforms.mixins.TapeformLayoutMixin.get_layout_template()>` method.
 
 
 Overriding field templates
@@ -79,16 +79,16 @@ As you can see, you can override the templates for fields based on the `field na
 and also based on the `field class`.
 
 If you need to select the field template depending on other things, you can
-overwrite the ``get_field_template`` method (which is defined in the
-``TapeformMixin``). The method receives a ``BoundField`` instance for the template
-selection.
+overwrite the :py:meth:`get_field_template
+<tapeforms.mixins.TapeformMixin.get_field_template()>` method. It receives a
+``BoundField`` instance for the template selection.
 
 
 Overriding widget templates
 ---------------------------
 
 In the context of `django-tapeforms` and `Django` itself, the widget template is
-used for the the actual input element.
+used for the actual input element.
 
 If you want to override the template used for rendering widgets, you can change
 the ``template_name`` by subclassing the widget classes but this requires much effort.
@@ -110,19 +110,20 @@ To make this easier, the `TapeformMixin` provided a helper to set the widget
 
 
 If you need to select the widget template based on other things, you can overwrite
-the ``get_widget_template`` method (which is defined in the ``TapeformMixin``). The
-method receives the field name as ``str`` and the ``Field`` instance.
+the :py:meth:`get_widget_template
+<tapeforms.mixins.TapeformMixin.get_widget_template()>` method. It receives the
+field name as ``str`` and the ``Field`` instance.
 
 
-Changing the applied css classes
+Changing the applied CSS classes
 --------------------------------
 
-When you render the form using `django-tapeforms` you can apply css classes to
-the field, label and widget.
+When you render the form using `django-tapeforms` you can apply CSS classes to
+the field container, label and widget.
 
-This is done using the properties ``field_container_css_class``, ``label_css_class``
-and ``widget_css_class``.
+This is done using the properties ``field_container_css_class``,
+``field_label_css_class`` and ``widget_css_class``.
 
-For all css class properties, there are methods to override the applied css class
+For all CSS class properties, there are methods to override the applied CSS class
 per field. Please refer to the :doc:`API Reference <api_mixins>` to learn what
-arguments are passed to the css class methods.
+arguments are passed to the CSS class methods.

--- a/tapeforms/contrib/bootstrap.py
+++ b/tapeforms/contrib/bootstrap.py
@@ -17,6 +17,8 @@ class BootstrapTapeformMixin(TapeformMixin):
     field_container_css_class = 'form-group'
     #: All widgets need a css class "form-control" (expect checkboxes).
     widget_css_class = 'form-control'
+    #: Use a special class to invalid field's widget.
+    widget_invalid_css_class = 'is-invalid'
 
     #: Widgets with multiple inputs require some extra care (don't use ul, etc.)
     widget_template_overrides = {
@@ -61,18 +63,3 @@ class BootstrapTapeformMixin(TapeformMixin):
             return 'form-check-input'
 
         return super().get_widget_css_class(field_name, field)
-
-    def add_error(self, field_name, error):
-        """
-        The method is overwritten to append 'is-invalid' to the css class of the
-        field's widget.
-        """
-        super().add_error(field_name, error)
-
-        if field_name in self.fields:
-            field = self.fields[field_name]
-            class_names = field.widget.attrs.get('class', '').split(' ')
-
-            if 'is-invalid' not in class_names:
-                class_names.append('is-invalid')
-                field.widget.attrs['class'] = ' '.join(class_names)

--- a/tapeforms/contrib/foundation.py
+++ b/tapeforms/contrib/foundation.py
@@ -13,9 +13,9 @@ class FoundationTapeformMixin(TapeformMixin):
     layout_template = 'tapeforms/layouts/foundation.html'
     #: Use a special field template for Foundation compatible forms.
     field_template = 'tapeforms/fields/foundation.html'
-    #: Add a special class to invalid field's label.
+    #: Use a special class to invalid field's label.
     field_label_invalid_css_class = 'is-invalid-label'
-    #: Add a special class to invalid field's widget.
+    #: Use a special class to invalid field's widget.
     widget_invalid_css_class = 'is-invalid-input'
 
     #: Widgets with multiple inputs require some extra care (don't use ul, etc.)
@@ -23,21 +23,6 @@ class FoundationTapeformMixin(TapeformMixin):
         forms.RadioSelect: 'tapeforms/widgets/foundation_multipleinput.html',
         forms.CheckboxSelectMultiple: 'tapeforms/widgets/foundation_multipleinput.html'
     }
-
-    def get_field_label_css_class(self, bound_field):
-        """
-        Appends 'is-invalid-label' if field has errors.
-        """
-        class_name = super().get_field_label_css_class(bound_field)
-
-        if bound_field.errors:
-            if not class_name:
-                class_name = self.field_label_invalid_css_class
-            else:
-                class_name = '{} {}'.format(
-                    class_name, self.field_label_invalid_css_class)
-
-        return class_name
 
     def get_field_template(self, bound_field, template_name=None):
         """
@@ -53,18 +38,11 @@ class FoundationTapeformMixin(TapeformMixin):
 
         return template_name
 
-    def add_error(self, field_name, error):
+    def apply_widget_invalid_options(self, field_name):
         """
-        The method is overwritten to append 'is-invalid-input' to the css class
-        of the field's widget.
+        Set ARIA attribute to the form's field widget.
         """
-        super().add_error(field_name, error)
+        super().apply_widget_invalid_options(field_name)
 
-        if field_name in self.fields:
-            widget = self.fields[field_name].widget
-            widget.attrs['aria-invalid'] = 'true'
-
-            class_names = widget.attrs.get('class', '').split(' ')
-            if self.widget_invalid_css_class not in class_names:
-                class_names.append(self.widget_invalid_css_class)
-                widget.attrs['class'] = ' '.join(class_names)
+        widget = self.fields[field_name].widget
+        widget.attrs['aria-invalid'] = 'true'

--- a/tapeforms/contrib/foundation.py
+++ b/tapeforms/contrib/foundation.py
@@ -37,12 +37,3 @@ class FoundationTapeformMixin(TapeformMixin):
             return 'tapeforms/fields/foundation_fieldset.html'
 
         return template_name
-
-    def apply_widget_invalid_options(self, field_name):
-        """
-        Set ARIA attribute to the form's field widget.
-        """
-        super().apply_widget_invalid_options(field_name)
-
-        widget = self.fields[field_name].widget
-        widget.attrs['aria-invalid'] = 'true'

--- a/tapeforms/mixins.py
+++ b/tapeforms/mixins.py
@@ -335,10 +335,12 @@ class TapeformMixin(TapeformLayoutMixin):
         Applies additional widget options for an invalid field.
 
         This method is called when there is some error on a field to apply
-        additional options on its widget, like adding a CSS class. For that,
-        it uses the `get_widget_invalid_css_class` method to determine if the
-        widget CSS class should be changed. If a CSS class is returned, it is
-        appended to the current value of the class property of the widget.
+        additional options on its widget. It does the following:
+
+        * Sets the aria-invalid property of the widget for accessibility.
+        * Adds an invalid CSS class, which is determined by the returned value
+          of `get_widget_invalid_css_class` method. If a CSS class is returned,
+          it is appended to the current value of the class property of the widget.
 
         :param field_name: A field name of the form.
         """
@@ -350,6 +352,8 @@ class TapeformMixin(TapeformLayoutMixin):
                 class_name = '{} {}'.format(
                     field.widget.attrs['class'], class_name)
             field.widget.attrs['class'] = class_name
+
+        field.widget.attrs['aria-invalid'] = 'true'
 
     def get_widget_invalid_css_class(self, field_name, field):
         """

--- a/tapeforms/mixins.py
+++ b/tapeforms/mixins.py
@@ -84,7 +84,7 @@ class TapeformMixin(TapeformLayoutMixin):
     #: The CSS class to apply to the form-field container element.
     field_container_css_class = 'form-field'
 
-    #: Optional CSS class to append to the rendered field label tag.
+    #: CSS class to append to the rendered field label tag. Optional.
     field_label_css_class = None
 
     #: A dictionary of form-field names and/or widget classes to override
@@ -92,12 +92,12 @@ class TapeformMixin(TapeformLayoutMixin):
     #: Optional.
     widget_template_overrides = None
 
-    #: Optiona CSS lass to append to the widget attributes. Optional.
+    #: CSS class to append to the widget attributes. Optional.
     widget_css_class = None
 
     def __init__(self, *args, **kwargs):
         """
-        The init method is overwritten to apply widget templates and css classes.
+        The init method is overwritten to apply widget templates and CSS classes.
         """
         super().__init__(*args, **kwargs)
 
@@ -113,8 +113,8 @@ class TapeformMixin(TapeformLayoutMixin):
         Preference of template selection:
 
         1. Provided method argument `template_name`
-        2. Templete from `field_template_overrides` selected by field name
-        3. Templete from `field_template_overrides` selected by field class
+        2. Template from `field_template_overrides` selected by field name
+        3. Template from `field_template_overrides` selected by field class
         4. Form class property `field_template`
         5. Globally defined default template from `defaults.LAYOUT_FIELD_TEMPLATE`
 
@@ -142,23 +142,23 @@ class TapeformMixin(TapeformLayoutMixin):
 
     def get_field_container_css_class(self, bound_field):
         """
-        Returns the container css class to use when rendering a field template.
+        Returns the container CSS class to use when rendering a field template.
 
         By default, returns the Form class property `field_container_css_class`.
 
-        :param bound_field: `BoundField` instance to return css class for.
-        :return: A css class string.
+        :param bound_field: `BoundField` instance to return CSS class for.
+        :return: A CSS class string.
         """
         return self.field_container_css_class or None
 
     def get_field_label_css_class(self, bound_field):
         """
-        Returns the optional label css class to use when rendering a field template.
+        Returns the optional label CSS class to use when rendering a field template.
 
-        By default, returns `None` which means "no css class".
+        By default, returns `None` which means "no CSS class".
 
-        :param bound_field: `BoundField` instance to return css class for.
-        :return: A css class string or `None`
+        :param bound_field: `BoundField` instance to return CSS class for.
+        :return: A CSS class string or `None`
         """
         return self.field_label_css_class or None
 
@@ -175,9 +175,9 @@ class TapeformMixin(TapeformLayoutMixin):
         * errors: `ErrorList` instance with errors of the field
         * required: Boolean flag to signal if the field is required or not
         * label: The label text of the field
-        * label_css_class: The optional label css class, might be `None`
+        * label_css_class: The optional label CSS class, might be `None`
         * help_text: Optional help text for the form field. Might be `None`
-        * container_css_class: The css class for the field container.
+        * container_css_class: The CSS class for the field container.
         * widget_class_name: Lowercased version of the widget class name (e.g. 'textinput')
         * widget_input_type: `input_type` property of the widget instance,
           falls back to `widget_class_name` if not available.
@@ -210,7 +210,7 @@ class TapeformMixin(TapeformLayoutMixin):
 
     def apply_widget_options(self, field_name):
         """
-        Apply additional widget options like changing the input type of DateInput
+        Applies additional widget options like changing the input type of DateInput
         and TimeInput to "date" / "time" to enable Browser date pickers or other
         attributes/properties.
         """
@@ -248,8 +248,8 @@ class TapeformMixin(TapeformLayoutMixin):
         for a form field.
 
         Preference of template selection:
-            1. Templete from `widget_template_overrides` selected by field name
-            2. Templete from `widget_template_overrides` selected by widget class
+            1. Template from `widget_template_overrides` selected by field name
+            2. Template from `widget_template_overrides` selected by widget class
 
         By default, returns `None` which means "use Django's default widget template".
 
@@ -271,11 +271,11 @@ class TapeformMixin(TapeformLayoutMixin):
 
     def apply_widget_css_class(self, field_name):
         """
-        Applies css classes to widgets if available.
+        Applies CSS classes to widgets if available.
 
-        The method uses the `get_widget_template` method to determine if the widget
-        template should be exchanged. If a template is available, the template_name
-        property of the widget instance is updated.
+        The method uses the `get_widget_css_class` method to determine if the widget
+        CSS class should be changed. If a CSS class is returned, it is appended to
+        the current value of the class property of the widget instance.
 
         :param field_name: A field name of the form.
         """
@@ -290,13 +290,13 @@ class TapeformMixin(TapeformLayoutMixin):
 
     def get_widget_css_class(self, field_name, field):
         """
-        Returns the optional widget css class to use when rendering the
+        Returns the optional widget CSS class to use when rendering the
         form's field widget.
 
-        By default, returns `None` which means "no css class / no change".
+        By default, returns `None` which means "no CSS class / no change".
 
         :param field_name: The field name of the corresponding field for the widget.
-        :param field: `Field` instance to return css class for.
-        :return: A css class string or `None`
+        :param field: `Field` instance to return CSS class for.
+        :return: A CSS class string or `None`
         """
         return self.widget_css_class or None

--- a/tests/contrib/test_bootstrap.py
+++ b/tests/contrib/test_bootstrap.py
@@ -44,16 +44,8 @@ class TestBootstrapTapeformMixin:
         assert form.get_widget_css_class(
             'my_field2', form.fields['my_field2']) == 'form-check-input'
 
-    def test_widget_css_class_invalid(self):
+    def test_apply_widget_invalid_options(self):
         form = DummyForm({})
-        form.full_clean()
-        css_classes = form.fields['my_field1'].widget.attrs['class'].split(' ')
-        assert 'is-invalid' in css_classes
-        assert 'form-control' in css_classes
-
-    def test_add_error(self):
-        form = DummyForm({})
-        form.add_error(None, 'Non field error!')
-        form.add_error('my_field1', 'Error!')
-        css_classes = form.fields['my_field1'].widget.attrs['class'].split(' ')
-        assert 'is-invalid' in css_classes
+        widget = form.fields['my_field1'].widget
+        assert 'my_field1' in form.errors
+        assert widget.attrs['class'].strip() == 'form-control is-invalid'

--- a/tests/contrib/test_foundation.py
+++ b/tests/contrib/test_foundation.py
@@ -36,25 +36,14 @@ class TestFoundationTapeformMixin:
         assert form.get_field_template(
             form['my_field3'], 'field-template.html') == 'field-template.html'
 
-    def test_field_label_css_class_default(self):
-        form = DummyForm()
-        assert form.get_field_label_css_class(
-            form['my_field1']) is None
-
     def test_field_label_css_class_invalid(self):
         form = DummyForm({})
         assert form.get_field_label_css_class(
             form['my_field1']) == 'is-invalid-label'
 
-    def test_field_label_css_class_override_invalid(self):
-        form = DummyFormWithProperties({})
-        assert form.get_field_label_css_class(
-            form['my_field1']) == 'custom-label is-invalid-label'
-
-    def test_add_error(self):
+    def test_apply_widget_invalid_options(self):
         form = DummyForm({})
-        form.add_error(None, 'Non field error!')
-        form.add_error('my_field1', 'Error!')
         widget = form.fields['my_field1'].widget
+        assert 'my_field1' in form.errors
         assert widget.attrs['aria-invalid'] == 'true'
         assert widget.attrs['class'].strip() == 'is-invalid-input'

--- a/tests/contrib/test_foundation.py
+++ b/tests/contrib/test_foundation.py
@@ -45,5 +45,4 @@ class TestFoundationTapeformMixin:
         form = DummyForm({})
         widget = form.fields['my_field1'].widget
         assert 'my_field1' in form.errors
-        assert widget.attrs['aria-invalid'] == 'true'
         assert widget.attrs['class'].strip() == 'is-invalid-input'

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -28,11 +28,13 @@ class DummyFormWithProperties(DummyForm):
     }
     field_container_css_class = 'form-row-custom'
     field_label_css_class = 'custom-label'
+    field_label_invalid_css_class = 'invalid-label'
     widget_template_overrides = {
         'my_field2': 'field2-widget.html',
         forms.NumberInput: 'integer-widget.html'
     }
     widget_css_class = 'some-widget-cssclass'
+    widget_invalid_css_class = 'invalid-widget'
 
 
 class DateTimeDummyForm(TapeformMixin, forms.Form):
@@ -131,6 +133,11 @@ class TestFieldMethods:
         assert form.get_field_label_css_class(
             form['my_field1']) == 'custom-label'
 
+    def test_get_field_label_css_class_invalid(self):
+        form = DummyFormWithProperties({})
+        assert form.get_field_label_css_class(
+            form['my_field1']) == 'custom-label invalid-label'
+
     def test_get_field_label_css_class_default(self):
         form = DummyForm()
         assert form.get_field_label_css_class(
@@ -217,3 +224,14 @@ class TestWidgetMethods:
         form = DummyForm()
         assert form.get_widget_css_class(
             'my_field1', form.fields['my_field1']) is None
+
+    def test_apply_widget_invalid_options_css_class(self):
+        form = DummyFormWithProperties({})
+        assert 'my_field1' in form.errors
+        assert form.fields['my_field1'].widget.attrs['class'] == (
+            'my-css some-widget-cssclass invalid-widget')
+
+    def test_apply_widget_invalid_options_default(self):
+        form = DummyForm({})
+        assert 'my_field1' in form.errors
+        assert form.fields['my_field1'].widget.attrs['class'] == 'my-css'

--- a/tests/test_mixins.py
+++ b/tests/test_mixins.py
@@ -234,4 +234,6 @@ class TestWidgetMethods:
     def test_apply_widget_invalid_options_default(self):
         form = DummyForm({})
         assert 'my_field1' in form.errors
-        assert form.fields['my_field1'].widget.attrs['class'] == 'my-css'
+        widget = form.fields['my_field1'].widget
+        assert widget.attrs['aria-invalid'] == 'true'
+        assert widget.attrs['class'] == 'my-css'


### PR DESCRIPTION
Bootstrap and Foundation mixins are both adding additional CSS classes to the label and widget of invalid fields. As it is a common case, it moves this possibility to the `TapeformMixin` class and adapts contrib mixins to make use of it.

I have tried to follow the same behavior of other methods for the widget CSS class - e.g. `apply_widget_invalid_options` is calling `get_widget_invalid_css_class` as for `apply_widget_css_class` for example. I have chosen `_options` instead `_css_class` as it can be used to set other attributes than only the CSS class - as the Foundation mixin. For the label, it is done directly in `get_field_label_css_class`.

Reviews and feedback are welcome! :)

----

Note: it depends on #2 and will be moved to upstream repository as soon it is merged.